### PR TITLE
Add handling of ArchiveDescription

### DIFF
--- a/bin/upload.js
+++ b/bin/upload.js
@@ -10,10 +10,11 @@ program
   .option('-v, --vault-name <vaultName>', 'Vault name')
   .option('-r --region <region>', 'Region', 'us-west-2')
   .option('-c --concurency <concurency>', 'How much uploads concurently', '20')
+  .option('-d, --detail <detail>', 'Detailed description of the file', '')
   .description('Multipart file upload to glacier')
   .action((file, options) => {
-    const { vaultName, region, concurency } = options;
-    uploader.upload(file, vaultName, region, concurency);
+    const { vaultName, region, concurency, detail } = options;
+    uploader.upload(file, vaultName, region, concurency, detail);
   });
 
 program.parse(process.argv);

--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -42,13 +42,13 @@ const uploader = {
       }
     });
   },
-  upload: (file, vaultName, region, concurency) => {
+  upload: (file, vaultName, region, concurency, archiveDescription) => {
     glacier = new AWS.Glacier({ region });
 
     const filePath = path.resolve(file);
     const { size: archiveSize } = fs.statSync(filePath);
     const { partSize, parts } = uploader.calculatePartSize(archiveSize);
-    const initParams = { partSize: partSize.toString(), vaultName, accountId };
+    const initParams = { partSize: partSize.toString(), vaultName, accountId, archiveDescription: archiveDescription };
 
     uploader.archiveSize = archiveSize;
     uploader.vaultName = vaultName;


### PR DESCRIPTION
As per this [link at AWS](https://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html)
>Except for the optional archive description, S3 Glacier does not support any additional metadata for the archives. The archive ID is an opaque sequence of characters from which you cannot infer any meaning about the archive.  

This PR adds functionality of specifying that optional `ArchiveDescription`