### PR TITLE
Fix: Displaying actual error when upload cant be created.

### DIFF
--- a/lib/uploader.js
+++ b/lib/uploader.js
@@ -54,11 +54,12 @@ const uploader = {
     uploader.vaultName = vaultName;
     uploader.queue = queue(uploader.queueWorker, concurency);
 
-    glacier.initiateMultipartUpload(initParams, (err, { uploadId }) => {
+    glacier.initiateMultipartUpload(initParams, (err, uploadInfo) => {
       if (err) {
         console.log(err, err.stack);
         return false;
       }
+      const { uploadId } = uploadInfo;
       debug('Init multipart upload, id: %s ', uploadId);
 
       uploader.bar = new ProgressBar(


### PR DESCRIPTION
Currently, when an upload can not be created it shows following error message:

<details>
  <summary>Error [TypeError]: Cannot destructure property 'uploadId' of 'object null' as it is null.</summary>

```
    at Response.<anonymous> (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/lib/uploader.js:57:57)
    at Request.<anonymous> (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/request.js:369:18)
    at Request.callListeners (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/request.js:688:14)
    at Request.transition (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/home/ubuntu/.npm/_npx/342/lib/node_modules/node-glacier-uploader/node_modules/aws-sdk/lib/request.js:690:12) {
  code: 'TypeError',
  time: 2021-10-07T11:52:53.731Z
}
```

</details>

This PR prevents that error and shows the actual error occurring when creating the upload.

Related to https://github.com/josser/node-glacier-uploader/issues/5